### PR TITLE
Publish v1.0.2 tag

### DIFF
--- a/.github/workflows/publish-v1.0.0.yml
+++ b/.github/workflows/publish-v1.0.0.yml
@@ -1,4 +1,4 @@
-name: Publish v1.0.1 tag
+name: Publish v1.0.2 tag
 
 on:
   push:
@@ -23,8 +23,8 @@ jobs:
         run: |
           set -euo pipefail
           version="$(tr -d '[:space:]' < VERSION)"
-          test "$version" = "1.0.1"
-          grep -Fq '## [1.0.1] - 2026-07-07' CHANGELOG.md
+          test "$version" = "1.0.2"
+          grep -Fq '## [1.0.2] - 2026-07-07' CHANGELOG.md
           if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1; then
             echo "Tag v${version} already exists; refusing to replace it."
             exit 1


### PR DESCRIPTION
Updates the existing one-time release helper from v1.0.1 to v1.0.2. After merge, the workflow verifies VERSION and CHANGELOG and creates the annotated v1.0.2 tag.