### PR TITLE
Fix release workflow dispatch after tag publication

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:
@@ -45,3 +46,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$tag" -m "NordVPN Linux Gateway Panel ${tag}"
           git push origin "$tag"
+
+      - name: Dispatch release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(tr -d '[:space:]' < VERSION)"
+          gh workflow run release.yml --ref main -f version="$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release, without the v prefix
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,9 +17,12 @@ permissions:
 jobs:
   validate-and-release:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
       - name: Install validation tools
@@ -30,7 +39,7 @@ jobs:
           python3 scripts/check-version-sync.py
           version="$(tr -d '[:space:]' < VERSION)"
           test -n "$version"
-          test "$GITHUB_REF_NAME" = "v${version}"
+          test "$RELEASE_TAG" = "v${version}"
           grep -Eq "^## \[${version//./\.}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md
           VPN_WEB_PASSWORD=test VPN_WEB_SECRET_KEY=test \
             python3 -c 'import app; assert app.APP_VERSION == open("VERSION", encoding="utf-8").read().strip()'
@@ -95,7 +104,7 @@ jobs:
         run: |
           set -euo pipefail
           version="$(tr -d '[:space:]' < VERSION)"
-          gh release create "$GITHUB_REF_NAME" \
+          gh release create "$RELEASE_TAG" \
             dist/* \
             --verify-tag \
             --latest \

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -73,11 +73,10 @@ Confirm:
 
 After the release pull request is approved and merged:
 
-```bash
-git switch main
-git pull --ff-only
-git tag -a v1.0.0 -m "NordVPN Linux Gateway Panel v1.0.0"
-git push origin v1.0.0
-```
+1. Open **Actions**.
+2. Select **Publish current release tag**.
+3. Run the workflow from `main` with the version number without the `v` prefix.
+4. Confirm that the workflow creates the annotated `vX.Y.Z` tag and explicitly dispatches the **Release** workflow.
+5. Confirm that **Release** validates the tagged source, creates the ZIP and tar.gz archives plus `SHA256SUMS`, and publishes the GitHub Release as Latest.
 
-Pushing the annotated tag runs the release workflow, validates the tagged source again, creates source archives and SHA-256 checksums, and publishes the GitHub Release.
+If a tag already exists because a previous publication stopped before the release workflow ran, manually run **Release** from `main` with the same version number. The workflow checks out and validates the existing tag before publishing any assets.


### PR DESCRIPTION
## Summary

Fix the release publication chain when the annotated tag is created by the `Publish current release tag` workflow.

GitHub does not trigger a second push-based workflow from events created with the repository `GITHUB_TOKEN`. As a result, `v1.0.3` was tagged successfully but the `Release` workflow did not start.

## Changes

- Add `workflow_dispatch` with a required version input to `.github/workflows/release.yml`.
- Resolve and check out the exact `vX.Y.Z` tag for both tag-push and manual-dispatch runs.
- Explicitly dispatch `release.yml` after the tag is created.
- Grant only the required `actions: write` permission to the tag publisher.
- Document the normal publication flow and the recovery path for an existing tag.

## Security and fail-closed impact

- No application, routing, DNS, nftables, systemd, installer, updater, or runtime configuration changes.
- No new repository secrets or credentials.
- Existing release validation remains mandatory before assets are published.
- The release workflow still validates tag/version consistency and builds archives from the tagged source, not from the workflow branch.

## Validation

- Reviewed both workflow event paths: tag push and explicit `workflow_dispatch`.
- The existing `v1.0.3` tag can be published by manually running `Release` with version `1.0.3` after this PR is merged.
- CI must pass before merge.